### PR TITLE
fix ib update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ARG PLANTUML_SCRIPT='#!/bin/sh \njava -jar -Dfile.encoding=$PLANTUML_ENCODING /o
 
 ENV PLANTUML_ENCODING=en_US.UTF-8
 
+RUN apk add -X https://nl.alpinelinux.org/alpine/edge/main -u alpine-keys --allow-untrusted
+
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
     && echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \


### PR DESCRIPTION
Fix `ib update` by adding alpine keys, allowing untrusted (old) keys.

Source: https://stackoverflow.com/questions/73374745/error-http-dl-4-alpinelinux-org-alpine-edge-testing-untrusted-signature

Note: This issue should be sorted at upstream image `openjdk:8-jre-alpine`, however without `allow-untrusted` flag the key is not working/synced. This option should be revised in future due to security risks.